### PR TITLE
Add GitHub links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,3 +21,5 @@ Suggests:
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Config/testthat/edition: 3
+URL: https://github.com/lionel-/codegrip
+BugReports: https://github.com/lionel-/codegrip/issues


### PR DESCRIPTION
Various usethis functions that I use alot, e.g., `browse_github()`, rely on finding these URLs in DESCRIPTION.