### PR TITLE
Some minor changes to make LSP use easier

### DIFF
--- a/R/ast.R
+++ b/R/ast.R
@@ -8,19 +8,33 @@ parse_xml <- function(info) {
   read_xml(xml_text)
 }
 
-parse_info <- function(file = "", text = NULL, lines = NULL) {
+parse_info <- function(file = "", text = NULL, lines = NULL, xml = NULL) {
   if (!is_null(text)) {
     lines <- as_lines(text)
   }
   list(
     file = file,
-    lines = lines
+    lines = lines,
+    xml = xml
   )
 }
 
-is_info <- function(x) {
-  is.list(x) && all(c("file", "lines") %in% names(x))
+parse_info_complete <- function(info) {
+  if (is.null(info$lines)) {
+    info$lines <- readLines(info$file)
+  }
+
+  if (is.null(info$xml)) {
+    info$xml <- parse_xml(info)
+  }
+
+  info
 }
+
+is_info <- function(x) {
+  is.list(x) && all(c("file", "lines", "xml") %in% names(x))
+}
+
 check_info <- function(info,
                        arg = caller_arg(info),
                        call = caller_env()) {

--- a/R/reshape.R
+++ b/R/reshape.R
@@ -26,9 +26,8 @@ can_reshape <- function(data) {
 }
 
 reshape_info <- function(line, col, ..., info, to = NULL) {
-  xml <- parse_xml(info)
-
-  call <- find_function_call(line, col, data = xml)
+  info <- parse_info_complete(info)
+  call <- find_function_call(line, col, data = info$xml)
   if (is_null(call)) {
     return()
   }


### PR DESCRIPTION
- Allows for passing pre-calculated `xml` parse data as part of the `reshape_info(info = )` parameter, since this is already pre-parsed by the lsp.
- Exports `reshape_info`

The `reshape_info()` interface is just about perfect for the LSP as it is. You can see how it's used in this function in my fork of `{languageserver}` [in these lines](https://github.com/REditorSupport/languageserver/compare/master...dgkf:languageserver:dev/codegrip-reshape#diff-13daf9a50454388f93023849feae7d28ec8977d4c922b8bb3241727d3778aa78R134-R145). However, the RStudio addin and emacs interfaces have more bespoke wrappers. Since the rest of the logic is lsp-implementation-specific, it seemed most natural to just export `reshape_info`, but I would understand if you'd prefer to keep a more consistent with the other tool interfaces.