### PR TITLE
Single indent the long "flat" form of function definitions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Suggests:
     rstudioapi,
     testthat (>= 3.0.0)
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Config/testthat/edition: 3
 URL: https://github.com/lionel-/codegrip
 BugReports: https://github.com/lionel-/codegrip/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,6 @@
+# codegrip (development version)
+
+* The long "flat" form for function definitions now aligns arguments using a
+  single indent rather than a double indent, which follows the
+  [tidyverse style guide](https://style.tidyverse.org/functions.html#long-lines-1)
+  (#20).

--- a/R/reshape-addin.R
+++ b/R/reshape-addin.R
@@ -15,7 +15,7 @@
 #'   Note that for function definitions, `addin_reshape()` cycles through two
 #'   different long shapes. The traditional L form uses more horizontal space
 #'   whereas the flat form uses less horizontal space and the arguments are
-#'   always aligned at double indent:
+#'   always aligned at single indent:
 #'   ```
 #'   foo <- function(a, b, c) {
 #'     NULL

--- a/R/reshape-call.R
+++ b/R/reshape-call.R
@@ -68,10 +68,8 @@ node_call_longer <- function(node, ..., L = FALSE, info) {
   if (prefix) {
     body <- node_text(node_call_body(node), info = info)
     suffix <- paste0(" ", body)
-    indent_factor <- 2
   } else {
     suffix <- ""
-    indent_factor <- 1
   }
 
   fn <- node_text(set[[1]], info = info)
@@ -82,11 +80,7 @@ node_call_longer <- function(node, ..., L = FALSE, info) {
     new_indent_n <- xml_col2(left_paren)
   } else {
     fn <- paste0(fn, left_paren_text, "\n")
-    if (prefix) {
-      new_indent_n <- current_indent_n + base_indent * indent_factor
-    } else {
-      new_indent_n <- current_indent_n + base_indent
-    }
+    new_indent_n <- current_indent_n + base_indent
   }
 
   if (L) {
@@ -125,7 +119,7 @@ node_call_longer <- function(node, ..., L = FALSE, info) {
     if (L) {
       arg_indent_n <- new_indent_n - current_indent_n - arg_parent_indent_n
     } else {
-      arg_indent_n <- base_indent * indent_factor - arg_parent_indent_n
+      arg_indent_n <- base_indent - arg_parent_indent_n
     }
 
     if (length(arg)) {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ codegrip provides [RStudio addins](http://rstudio.github.io/rstudioaddins/) and 
 
 <img src="man/figures/README/reshape-call.svg"/>
 
-Note that for function definitions, `addin_reshape` cycles through two different long shapes. The traditional L form uses more horizontal space whereas the flat form uses less horizontal space and the arguments are always aligned at double indent:
+Note that for function definitions, `addin_reshape` cycles through two different long shapes. The traditional L form uses more horizontal space whereas the flat form uses less horizontal space and the arguments are always aligned at single indent:
 
 <img src="man/figures/README/reshape-def.svg"/>
 
@@ -61,7 +61,7 @@ Not yet implemented:
 
 ## Using in Visual Studio Code
 
-`addin_reshape` is available for keybinding in VS Code. See [here](https://github.com/REditorSupport/vscode-R/wiki/RStudio-addin-support#enabling-rstudio-addin-support) for instructions on enabling general addin support. 
+`addin_reshape` is available for keybinding in VS Code. See [here](https://github.com/REditorSupport/vscode-R/wiki/RStudio-addin-support#enabling-rstudio-addin-support) for instructions on enabling general addin support.
 
 Once addins are enabled, add the following to `keybindings.json`:
 

--- a/man/addin_reshape.Rd
+++ b/man/addin_reshape.Rd
@@ -23,7 +23,7 @@ list(
 Note that for function definitions, \code{addin_reshape()} cycles through two
 different long shapes. The traditional L form uses more horizontal space
 whereas the flat form uses less horizontal space and the arguments are
-always aligned at double indent:
+always aligned at single indent:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{foo <- function(a, b, c) \{
   NULL

--- a/tests/testthat/_snaps/reshape-call.md
+++ b/tests/testthat/_snaps/reshape-call.md
@@ -14,7 +14,7 @@
       )
       
       function(
-          a
+        a
       ) NULL
     Code
       print_longer("(b, c)")
@@ -25,8 +25,8 @@
       )
       
       function(
-          b,
-          c
+        b,
+        c
       ) NULL
     Code
       print_longer("(a, b, c)")
@@ -38,9 +38,9 @@
       )
       
       function(
-          a,
-          b,
-          c
+        a,
+        b,
+        c
       ) NULL
     Code
       print_longer("(a = 1, b, c = 3)")
@@ -52,9 +52,9 @@
       )
       
       function(
-          a = 1,
-          b,
-          c = 3
+        a = 1,
+        b,
+        c = 3
       ) NULL
     Code
       # Leading indentation is preserved. First line is not indented
@@ -73,7 +73,7 @@
         )
       
         function(
-            a
+          a
         ) NULL
     Code
       print_longer("  (a, b)")
@@ -84,8 +84,8 @@
         )
       
         function(
-            a,
-            b
+          a,
+          b
         ) NULL
     Code
       # Multiline args are indented as is
@@ -100,11 +100,11 @@
       )
       
       function(
-          a,
-          b = foo(
-            bar
-          ),
-          c
+        a,
+        b = foo(
+          bar
+        ),
+        c
       ) NULL
     Code
       print_longer("(a, b =\n  2, c)")
@@ -117,10 +117,10 @@
       )
       
       function(
-          a,
-          b =
-            2,
-          c
+        a,
+        b =
+          2,
+        c
       ) NULL
     Code
       print_longer("  (a, b = foo(\n    bar  \n  ), c)")
@@ -134,11 +134,11 @@
         )
       
         function(
-            a,
-            b = foo(
-              bar  
-            ),
-            c
+          a,
+          b = foo(
+            bar  
+          ),
+          c
         ) NULL
     Code
       # Wrong indentation is preserved
@@ -153,11 +153,11 @@
       )
       
       function(
-          a,
-          b = foo(
-          bar
-          ),
-          c
+        a,
+        b = foo(
+        bar
+        ),
+        c
       ) NULL
     Code
       print_longer("  (a, b = foo(\n  bar\n), c)")
@@ -171,11 +171,11 @@
         )
       
         function(
-            a,
-            b = foo(
-            bar
-          ),
-            c
+          a,
+          b = foo(
+          bar
+        ),
+          c
         ) NULL
 
 # can reshape call longer (L shape)

--- a/tests/testthat/_snaps/reshape.md
+++ b/tests/testthat/_snaps/reshape.md
@@ -64,7 +64,7 @@
     Output
       i: 1
       function(
-          a
+        a
       ) NULL
       
       i: 2
@@ -72,7 +72,7 @@
       
       i: 3
       function(
-          a
+        a
       ) NULL
       
     Code
@@ -86,9 +86,9 @@
       
       i: 2
       function(
-          a,
-          b = 1,
-          c
+        a,
+        b = 1,
+        c
       ) NULL
       
       i: 3
@@ -108,7 +108,7 @@
     Output
       i: 1
       if (
-          a
+        a
       ) NULL
       
       i: 2
@@ -120,7 +120,7 @@
     Output
       i: 1
       if (
-          a
+        a
       ) b else c
       
       i: 2
@@ -132,7 +132,7 @@
     Output
       i: 1
       while (
-          a
+        a
       ) NULL
       
       i: 2


### PR DESCRIPTION
Closes #20 

Aligns with https://github.com/tidyverse/style/pull/223

https://github.com/user-attachments/assets/14790459-da3d-4edf-b4ce-7af45a8ad45e

Also added a NEWS file

---


Note that there is currently an existing bug in codegrip when there is a function argument that is a call spanning multiple lines. Even if it starts with the right indentation we can't roundtrip it. It is unrelated to this PR (I think) but I wanted to call it out since you will see it in the snapshots.

Before this PR:

https://github.com/user-attachments/assets/35a86594-d42f-4c7b-9756-bab93a800be8

After this PR:


https://github.com/user-attachments/assets/32f8e7ea-fc3a-4c79-b2ce-2bc64ce1d56e

